### PR TITLE
support s390x arch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mirror.gcr.io/library/golang:latest
 COPY . /go/src/github.com/chmouel/gosmee
 WORKDIR /go/src/github.com/chmouel/gosmee
-RUN CGO_ENABLED=0 GOOS=linux go build -a  -ldflags="-s -w"  -installsuffix cgo -o gosmee .
+RUN CGO_ENABLED=0 GOARCH=s390x GOOS=linux go build -a  -ldflags="-s -w"  -installsuffix cgo -o gosmee .
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-240.1648458092
 COPY --from=0 /go/src/github.com/chmouel/gosmee/gosmee /usr/local/bin/gosmee

--- a/README.md
+++ b/README.md
@@ -96,6 +96,52 @@ You can add `--noReplay` if you only want the saving and not replaying.
 
 You will have a pretty colored emoji unless you specify `--nocolor` as argument.
 
+## Build image for your arch 
+
+```
+update GOARCH to your arch in Dockerfile, such as GOARCH=s390x
+podman build -t yourrepo/gosmee:s390x .
+podman push yourrepo/gosmee:s390x
+```
+
+## Deploy it on openshift
+
+```
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: gosmee-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gosmee-client
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gosmee-client
+    spec:
+      containers:
+        - name: gosmee-client
+          image: 'docker.io/zhengxiaomei123/gosmee:s390x'
+          args:
+            - 'https://smee.io/yHv1dESyg7BJmm4i'
+            - $(SVC)
+          env:
+            - name: SVC
+              value: >-
+                http://pipelines-as-code-controller-openshift-pipelines.apps.pli43-tt4.psi.ospqa.com
+      restartPolicy: Always
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+```
+
 ## Thanks
 
 - Most of the works is done by the [go-sse](github.com/r3labs/sse) library.


### PR DESCRIPTION
**Usage:** 
podman build -t yourrepo/gosmee:s390x .
podman push yourrepo/gosmee:s390x

**Create deployment.yaml to use it on openshift**
```
kind: Deployment
apiVersion: apps/v1
metadata:
  name: gosmee-client
spec:
  replicas: 1
  selector:
    matchLabels:
      app: gosmee-client
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: gosmee-client
    spec:
      containers:
        - name: gosmee-client
          image: 'docker.io/zhengxiaomei123/gosmee:s390x'
          args:
            - 'https://smee.io/yHv1dESyg7BJmm4i'
            - $(SVC)
          env:
            - name: SVC
              value: >-
                http://pipelines-as-code-controller-openshift-pipelines.apps.pli43-tt4.psi.ospqa.com
      restartPolicy: Always
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 25%
      maxSurge: 25%
  revisionHistoryLimit: 10
  progressDeadlineSeconds: 600
```