### PR TITLE
Ensure `content-type` is always `application/json`

### DIFF
--- a/gosmee/client.go
+++ b/gosmee/client.go
@@ -239,6 +239,7 @@ func (c goSmee) replayData(b []byte) error {
 	for k, v := range pm.headers {
 		req.Header.Add(k, v)
 	}
+	req.Header.Add("content-type", "application/json")
 	resp, err := client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
In order for the client to work with a Jenkins `/github-webhook/` target the `content-type: application/json` header must be present.