### PR TITLE
Optional fix and formatting for replay template

### DIFF
--- a/gosmee/templates/replay_script.tmpl.bash
+++ b/gosmee/templates/replay_script.tmpl.bash
@@ -1,11 +1,14 @@
 #!/bin/bash
-# Replay script with headers and json to the target controller
-# You can switch the targetURL to another one with the -l switch, i.e: your local debugge
-# It default to http://localhost:808
-# you can customze this target with the env variable GOSMEE_DEBUG_SERVICE
+#
+# Replay script with headers and JSON payload to the target controller.
+#
+# You can switch the targetURL to another one with the -l switch, which defaults
+# to http://localhost:8080.
+#
+# You can customze this target with the env variable: GOSMEE_DEBUG_SERVICE
 set -euxf
 cd $(dirname $(readlink -f $0))
 
-targetURL="{{.TargetURL}}"
+targetURL="{{ .TargetURL }}"
 [[ ${1:-""} == -l ]] && targetURL=${GOSMEE_DEBUG_SERVICE:-"http://localhost:8080"}
-curl -H "Content-Type: {{ .ContentType }}" {{.Headers}} -X POST -d @./{{ .FileBase }}.json ${targetURL}
+curl -sSi -H "Content-Type: {{ .ContentType }}" {{ .Headers }} -X POST -d @./{{ .FileBase }}.json ${targetURL}


### PR DESCRIPTION
An optional fix to a comment which now properly references 8080, along with a set of formatting fixes to "improve" the readability.

It also adds the use of the `-sSi` switches to the `curl` command so that once can see the response headers (`-i) without the progress meter (`-s`) while still seeing error messages (`-S`).