### PR TITLE
Add new line to server POST response payload

### DIFF
--- a/gosmee/server.go
+++ b/gosmee/server.go
@@ -134,7 +134,7 @@ func serve(c *cli.Context) error {
 		})
 		w.WriteHeader(http.StatusAccepted)
 
-		fmt.Fprintf(w, `{"status":%d, "channel": "%s", "message":"ok"}`, http.StatusAccepted, channel)
+		fmt.Fprintf(w, "{\"status\": %d, \"channel\": \"%s\", \"message\": \"ok\"}\n", http.StatusAccepted, channel)
 	})
 	config := goSmee{}
 


### PR DESCRIPTION
Commit message body:

    When replaying "saved" payloads created by `gosmee client --saveDir`
    the response payload printed by `curl` now has a new line character
    so the command-line prompt does not share the same line.