### PR TITLE
Use 1 MB buffers to avoid silent errors

### DIFF
--- a/gosmee/client.go
+++ b/gosmee/client.go
@@ -267,7 +267,7 @@ func (c goSmee) replayData(pm payloadMsg) error {
 func (c goSmee) clientSetup() error {
 	version := strings.TrimSpace(string(Version))
 	fmt.Fprintf(os.Stdout, "%sStarting gosmee version: %s\n", c.emoji("⇉", "green+b"), version)
-	client := sse.NewClient(c.smeeURL)
+	client := sse.NewClient(c.smeeURL, sse.ClientMaxBufferSize(1<<20))
 	client.Headers["User-Agent"] = fmt.Sprintf("gosmee/%s", version)
 	// this is to get nginx to work
 	client.Headers["X-Accel-Buffering"] = "no"

--- a/gosmee/client_test.go
+++ b/gosmee/client_test.go
@@ -3,6 +3,7 @@ package gosmee
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 )
@@ -20,7 +21,7 @@ var simpleJSON = `{
 
 func TestGoSmeeGood(t *testing.T) {
 	p := goSmee{}
-	m, err := p.parse([]byte(simpleJSON))
+	m, err := p.parse(time.Now().UTC(), []byte(simpleJSON))
 	assert.NilError(t, err)
 	assert.Equal(t, m.headers["X-Foo"], "bar")
 	assert.Equal(t, m.headers["User-Agent"], "gosmee")
@@ -34,6 +35,6 @@ func TestGoSmeeGood(t *testing.T) {
 
 func TestGoSmeeBad(t *testing.T) {
 	p := goSmee{}
-	pm, _ := p.parse([]byte(`xxxXXXxx`))
+	pm, _ := p.parse(time.Now().UTC(), []byte(`xxxXXXxx`))
 	assert.Equal(t, string(pm.body), "")
 }


### PR DESCRIPTION
See https://github.com/r3labs/sse/issues/158, "Improve receive message error handling."

Fixes https://github.com/chmouel/gosmee/issues/77, "`ERROR gosmee bufio.Scanner: token too long`".

I filed this as 2 separate commits so that the actual fix is separate from the logging changes I made as part of my debugging efforts (commit message body below for the supporting commit):

    Add log entries with req headers to aid debugging

    The new published log entries in both the client and server contain the
    the original payload headers, and for the server the request ID,
    allowing one to track down behaviors from know sources (e.g. GitHub
    posts a list of events it sent to a web hook with the headers used).

----

Layered on top of #83.