### PR TITLE
Fixed ERROR no headers found in message occurring every minute

### DIFF
--- a/gosmee/client.go
+++ b/gosmee/client.go
@@ -289,6 +289,15 @@ func (c goSmee) clientSetup() error {
 			return
 		}
 
+        if string(msg.Event) == "ping" {
+            return
+        } /* Without this we get 
+           * "ERROR no headers found in message"
+           * because apparently github sends
+           * a ping every minute but it's not
+           * documented anywhere for some reason
+           */
+
 		pm, err := c.parse(now, msg.Data)
 		if err != nil {
 			fmt.Fprintf(os.Stdout,


### PR DESCRIPTION
Apparently a 'ping' event with an empty message is sent every minute and it's read as an error.
So I just made the client ignore every event of type 'ping'