### PR TITLE
flake.nix: use go 1.21 for building…

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666694730,
-        "narHash": "sha256-/PRSvfO3Y2Tkr5Cbh5wgeHHC2PvkzSKpt0En+wc02ag=",
+        "lastModified": 1699973119,
+        "narHash": "sha256-Jg80rekrOZh/sG0DQWZ24k9lAHNyrbs7oBKD4ys6nb0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08e91c641b1f19dcd9b39998ab41935ceef344a2",
+        "rev": "a2b6873f0b7f1468fa4a3e759c426b28dae8908d",
         "type": "github"
       },
       "original": {
@@ -21,13 +21,31 @@
         "utils": "utils"
       }
     },
-    "utils": {
+    "systems": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
         gosmee = pkgs.callPackage ./default.nix {
           packageSrc = self;
-          buildGoModule = pkgs.buildGo119Module;
+          buildGoModule = pkgs.buildGo121Module;
           version = version;
         };
       in
@@ -34,7 +34,7 @@
         devShell = pkgs.mkShell
           {
             nativeBuildInputs = [
-              pkgs.go_1_19
+              pkgs.go_1_21
               pkgs.gnumake
               pkgs.pre-commit # needed for pre-commit install
               pkgs.git # needed for pre-commit install


### PR DESCRIPTION
… and update nixpkgs as well.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
