### PR TITLE
feat: Add --new-url flag to fetch redirect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,13 +206,16 @@ source <(gosmee completion zsh)
 If you plan to use <https://smee.io>, you can generate your own smee URL by
 visiting <https://smee.io/new>.
 
+If you want to use <https://hook.pipelinesascode.com> then you can directly
+generate a URL with  the `-u / --new-url` flag to generate one.
+
 Once you have it, the basic usage is:
 
 ```shell
 gosmee client https://smee.io/aBcDeF https://localhost:8080
 ```
 
-This command will relay all payloads received at the smee URL to a service
+This command will relay all payloads received by the smee URL to a service
 running on <http://localhost:8080>.
 
 You can also save all relays as shell scripts for easy replay:

--- a/gosmee/app_test.go
+++ b/gosmee/app_test.go
@@ -1,0 +1,27 @@
+package gosmee
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetNewHookURL_Success(t *testing.T) {
+	expectedURL := "https://example.com/redirected"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		fmt.Fprint(w, expectedURL)
+	}))
+	defer server.Close()
+
+	output, err := getNewHookURL(server.URL)
+	if err != nil {
+		t.Errorf("getNewHookURL() error = %v", err)
+	}
+	if output != expectedURL {
+		t.Errorf("getNewHookURL() output = %q, want %q", output, expectedURL)
+	}
+}

--- a/gosmee/flags.go
+++ b/gosmee/flags.go
@@ -71,6 +71,12 @@ var replayFlags = []cli.Flag{
 }
 
 var clientFlags = []cli.Flag{
+	&cli.BoolFlag{
+		Name:    "new-url",
+		Aliases: []string{"u"},
+		Usage:   "Generate a new URL from https://hook.pipelinesascode.com",
+		Value:   false,
+	},
 	&cli.StringFlag{
 		Name:    "channel",
 		Aliases: []string{"c"},


### PR DESCRIPTION
This commit introduces a new command-line flag `--new-url` (alias `-u`)
to gosmee.

When this flag is used, the application will:
1. Make a GET request to https://hook.pipelinesascode.com/new.
2. Capture the URL from the `Location` header of the redirect response.
3. Print the captured URL to standard output.
4. Exit.

The implementation includes:
- A new `getNewHookURL` function in `gosmee/app.go` that handles the
  HTTP request and redirect logic.
- The `--new-url` flag definition in `gosmee/flags.go` under commonFlags.
- Integration into the CLI application flow using a `Before` hook in
  `gosmee/app.go`.
- Comprehensive unit tests in `gosmee/app_test.go` for the new
  functionality, covering success and various error cases.
- Refactoring of `getNewHookURL` to accept the target URL as a parameter
  to improve testability.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
