### PR TITLE
docs: mention smee-sidecar as a method for mitigating caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,10 @@ This tool is intended for local development and testing environments only!
 It hasn't undergone thorough security and performance reviews and
 should not be deployed in production systems.
 
+[smee-sidecar](https://github.com/konflux-ci/smee-sidecar) is a service intended for
+monitoring gosmee deployments. It provides active health checks to verify that gosmee
+is serving requests.
+
 ## 🙏 Thanks
 
 - Most of the work is powered by the [go-sse](https://github.com/r3labs/sse) library.


### PR DESCRIPTION
Hi @chmouel!

For monitoring gosmee in Konflux clusters, we came up with this sidecar that runs active health checks between the smee server and client and verifies events are being forwarded.

If you're willing, I'd like to have it mentioned in some way as an option for monitoring gosmee. I think that the caveats section might be an option.

Let me know your thoughts.