### PR TITLE
agents/security issues investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ To only run the command for specific event types, use `--exec-on-events`:
 gosmee client --exec './handle-push.sh' --exec-on-events push --exec-on-events pull_request https://smee.io/aBcDeF http://localhost:8080
 ```
 
+By default, `--exec` runs with a minimal, safe environment (for example `PATH`, `HOME`, and locale-related variables), not the full gosmee process environment. To pass additional variables through, use `--exec-env-vars VAR_NAME` (repeat the flag for multiple names), or set `GOSMEE_EXEC_ENV_VARS` as a comma-separated list.
+
 The `--exec` command runs **synchronously** after the webhook is forwarded to the target URL (if replay is enabled). A slow command will delay processing of subsequent events. If you need asynchronous execution, background your command (e.g., `--exec './my-script.sh &'`). A non-zero exit code is logged as an error but does not stop processing further events.
 
 Both `--exec` and `--exec-on-events` also work with the `replay` command.
@@ -417,6 +419,9 @@ Running gosmee server behind nginx requires some configuration:
 Note: Long-running connections may occasionally cause errors with nginx. Contributions to debug this are most welcome.
 
 #### Security
+
+- `--replay-token` / `GOSMEE_REPLAY_TOKEN`: Require `Authorization: Bearer <token>` on `POST /replay/{channel}`. When set, the web UI will prompt for the token when you click Replay (stored in browser sessionStorage for convenience). When not set, the replay endpoint remains open for backward compatibility.
+- `--cors-origin` / `GOSMEE_CORS_ORIGIN`: Controls `Access-Control-Allow-Origin` for the SSE stream. Default is `*` (any origin can connect). Set a specific origin to restrict access. Set an empty string to omit the header entirely (same-origin only).
 
 For a full security reference — including webhook signature validation, IP restrictions, payload limits, channel name protection, and encrypted channels — see [SECURITY.md](./SECURITY.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,7 @@ internet → [gosmee server] → SSE stream → [gosmee client] → local servic
 |---|---|
 | Forged or tampered webhooks from untrusted senders | Signature validation, IP allowlisting |
 | Eavesdropping on the SSE relay stream | End-to-end encryption |
+| Unauthorized replay injection | `--replay-token` |
 | Payload-based resource exhaustion (DoS) | `--max-body-size`, channel name length limit |
 | Command injection via exec scripts | `--exec` hardening, signature validation, IP allowlisting |
 | Unauthorized access to protected channels | Encrypted channels with public-key authentication |
@@ -44,6 +45,8 @@ If you do nothing else, apply these controls before deploying gosmee in producti
 - [ ] Set `--max-body-size` to a sensible limit for your workloads
 - [ ] Run as a non-root user with minimal filesystem permissions
 - [ ] Enable encrypted channels for sensitive payloads
+- [ ] Set `--replay-token` if the replay endpoint is exposed to untrusted networks
+- [ ] Set `--cors-origin` to your dashboard URL if you do not want arbitrary websites connecting to the SSE stream
 - [ ] If using `--exec`, validate and sanitize all payload fields in scripts before passing them to shell commands
 
 ---
@@ -101,6 +104,32 @@ gosmee automatically detects the provider from the request headers and validates
 Requests with a missing or invalid signature are rejected with HTTP 401. When multiple secrets are configured, each is tried in turn — useful when migrating secrets or receiving webhooks from multiple sources. The overhead is negligible (~2 μs per request).
 
 Secrets can also be set via `GOSMEE_WEBHOOK_SIGNATURE` (comma-separated).
+
+---
+
+## Protecting the Replay Endpoint
+
+The `/replay/{channel}` endpoint re-sends a captured event to all SSE subscribers on that channel. This is useful for debugging and incident replay, but it is also a write path into your relay stream.
+
+Without authentication, anyone who can reach the server can POST to `/replay/{channel}` and inject payloads into any channel they can name.
+
+Set `--replay-token` (or `GOSMEE_REPLAY_TOKEN`) to require bearer-token authentication:
+
+```shell
+gosmee server --replay-token=MY_SECRET_TOKEN
+```
+
+When set, replay requests must include:
+
+```text
+Authorization: Bearer <token>
+```
+
+Missing or incorrect tokens are rejected with HTTP 401.
+
+The web UI Replay button will prompt you to enter the token when you first attempt to replay an event. The token is stored in your browser's sessionStorage for convenience during the session.
+
+If `--replay-token` is not set, the replay endpoint remains open for backward compatibility.
 
 ---
 
@@ -180,6 +209,27 @@ Encryption covers the **server-to-client SSE leg only**. Incoming webhook POST b
 | | TLS transport (use a reverse proxy) |
 
 Encryption requires gosmee's own server — smee.io is not supported.
+
+### Restricting SSE Cross-Origin Access
+
+The SSE endpoint (`/events/{channel}`) sets `Access-Control-Allow-Origin`. By default, it is `*`.
+
+That default means any website that knows a channel ID can open an `EventSource` connection and receive all payloads for that channel.
+
+Use `--cors-origin` (or `GOSMEE_CORS_ORIGIN`) to control this header:
+
+```shell
+# Default (backward compatible): allow all origins
+gosmee server --cors-origin="*"
+
+# Restrict browser access to one origin
+gosmee server --cors-origin="https://dashboard.example.com"
+
+# Omit the header entirely (same-origin browser access only)
+gosmee server --cors-origin=""
+```
+
+The default `*` preserves backward compatibility for existing deployments.
 
 ---
 

--- a/gosmee/app.go
+++ b/gosmee/app.go
@@ -193,6 +193,7 @@ non-publicly accessible endpoint, forward those requests to your local service.`
 							sseBufferSize:     c.Int("sse-buffer-size"),
 							execCommand:       c.String("exec"),
 							execOnEvents:      c.StringSlice("exec-on-events"),
+							execEnvVars:       c.StringSlice("exec-env-vars"),
 							encryptionKeyFile: c.String("encryption-key-file"),
 						},
 						logger:  logger,

--- a/gosmee/client.go
+++ b/gosmee/client.go
@@ -287,6 +287,7 @@ type replayDataOpts struct {
 	useHttpie                   bool // Use httpie instead of curl
 	execCommand                 string
 	execOnEvents                []string
+	execEnvVars                 []string
 	encryptionKeyFile           string
 }
 
@@ -370,7 +371,7 @@ func runExecCommand(ctx context.Context, rd *replayDataOpts, logger *slog.Logger
 
 	//nolint:gosec // Command is intentionally user-provided
 	cmd := exec.CommandContext(ctx, "sh", "-c", rd.execCommand)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(buildExecEnv(rd.execEnvVars),
 		"GOSMEE_EVENT_TYPE="+pm.eventType,
 		"GOSMEE_EVENT_ID="+pm.eventID,
 		"GOSMEE_CONTENT_TYPE="+pm.contentType,
@@ -406,6 +407,59 @@ func runExecCommand(ctx context.Context, rd *replayDataOpts, logger *slog.Logger
 	logger.InfoContext(ctx,
 		fmt.Sprintf("%sexec command completed successfully for event %s", emoji("✓", "green+b", rd.decorate), pm.eventType))
 	return nil
+}
+
+func buildExecEnv(extraVarNames []string) []string {
+	allowlist := []string{
+		"PATH",
+		"HOME",
+		"TMPDIR",
+		"TEMP",
+		"TMP",
+		"USER",
+		"USERNAME",
+		"LOGNAME",
+		"SHELL",
+		"LANG",
+		"LC_ALL",
+		"LC_CTYPE",
+		"TZ",
+	}
+
+	execEnv := make([]string, 0, len(allowlist)+len(extraVarNames))
+	seen := map[string]struct{}{}
+	addEnvVar := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		value, ok := os.LookupEnv(name)
+		if !ok {
+			return
+		}
+		execEnv = append(execEnv, name+"="+value)
+		seen[name] = struct{}{}
+	}
+
+	for _, name := range allowlist {
+		addEnvVar(name)
+	}
+	for _, envVar := range os.Environ() {
+		name, _, ok := strings.Cut(envVar, "=")
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(name, "LC_") {
+			addEnvVar(name)
+		}
+	}
+	for _, name := range extraVarNames {
+		addEnvVar(name)
+	}
+
+	return execEnv
 }
 
 // checkServerVersion verifies that the client version is compatible with the server version.

--- a/gosmee/client.go
+++ b/gosmee/client.go
@@ -294,7 +294,7 @@ func replayData(ropts *replayDataOpts, logger *slog.Logger, pm payloadMsg) error
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(ropts.targetCnxTimeout)*time.Second)
 	defer cancel()
 	//nolint:gosec // InsecureSkipVerify is controlled by user input for testing/self-signed certs
-	client := http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: !ropts.insecureTLSVerify}}}
+	client := http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: ropts.insecureTLSVerify}}}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ropts.targetURL, strings.NewReader(string(pm.body)))
 	if err != nil {
 		return err

--- a/gosmee/client_test.go
+++ b/gosmee/client_test.go
@@ -560,11 +560,28 @@ func TestReplayData(t *testing.T) {
 	})
 
 	t.Run("insecureTLSVerify flag", func(t *testing.T) {
-		// Based on client.go: InsecureSkipVerify: !ropts.insecureTLSVerify
-		// insecureTLSVerify: false => InsecureSkipVerify: true (should succeed with self-signed)
-		// insecureTLSVerify: true  => InsecureSkipVerify: false (should fail with self-signed)
+		// Based on client.go: InsecureSkipVerify: ropts.insecureTLSVerify
+		// insecureTLSVerify: false => InsecureSkipVerify: false (should fail with self-signed)
+		// insecureTLSVerify: true  => InsecureSkipVerify: true (should succeed with self-signed)
 
-		t.Run("insecureTLSVerify=false makes connection succeed", func(t *testing.T) {
+		t.Run("insecureTLSVerify=false makes connection fail", func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				// Should not be called
+				t.Fatal("server handler should not be called on TLS handshake failure")
+			}))
+			defer server.Close()
+
+			opts := replayDataOpts{
+				targetURL:         server.URL,
+				targetCnxTimeout:  5,
+				insecureTLSVerify: false, // so InsecureSkipVerify becomes false
+			}
+			err := replayData(&opts, logger, basePayload)
+			assert.Assert(t, err != nil)
+			assert.Assert(t, strings.Contains(err.Error(), "x509"), "Error message should contain x509: %v", err)
+		})
+
+		t.Run("insecureTLSVerify=true makes connection succeed", func(t *testing.T) {
 			var serverCalled bool
 			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				serverCalled = true
@@ -575,28 +592,11 @@ func TestReplayData(t *testing.T) {
 			opts := replayDataOpts{
 				targetURL:         server.URL,
 				targetCnxTimeout:  5,
-				insecureTLSVerify: false, // so InsecureSkipVerify becomes true
+				insecureTLSVerify: true, // so InsecureSkipVerify becomes true
 			}
 			err := replayData(&opts, logger, basePayload)
 			assert.NilError(t, err)
 			assert.Assert(t, serverCalled)
-		})
-
-		t.Run("insecureTLSVerify=true makes connection fail", func(t *testing.T) {
-			server := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-				// Should not be called
-				t.Fatal("server handler should not be called on TLS handshake failure")
-			}))
-			defer server.Close()
-
-			opts := replayDataOpts{
-				targetURL:         server.URL,
-				targetCnxTimeout:  5,
-				insecureTLSVerify: true, // so InsecureSkipVerify becomes false
-			}
-			err := replayData(&opts, logger, basePayload)
-			assert.Assert(t, err != nil)
-			assert.Assert(t, strings.Contains(err.Error(), "x509"), "Error message should contain x509: %v", err)
 		})
 	})
 

--- a/gosmee/client_test.go
+++ b/gosmee/client_test.go
@@ -565,7 +565,7 @@ func TestReplayData(t *testing.T) {
 		// insecureTLSVerify: true  => InsecureSkipVerify: true (should succeed with self-signed)
 
 		t.Run("insecureTLSVerify=false makes connection fail", func(t *testing.T) {
-			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 				// Should not be called
 				t.Fatal("server handler should not be called on TLS handshake failure")
 			}))
@@ -1379,6 +1379,31 @@ func TestIsOlderVersion(t *testing.T) {
 	}
 }
 
+func TestBuildExecEnv(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("HOME", "/tmp/home")
+	t.Setenv("LC_MESSAGES", "en_US.UTF-8")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "super-secret")
+	t.Setenv("CUSTOM_EXTRA", "enabled")
+
+	got := buildExecEnv([]string{"CUSTOM_EXTRA", "MISSING_EXTRA"})
+	envMap := make(map[string]string, len(got))
+	for _, item := range got {
+		name, value, found := strings.Cut(item, "=")
+		assert.Assert(t, found)
+		envMap[name] = value
+	}
+
+	assert.Equal(t, envMap["PATH"], "/usr/bin:/bin")
+	assert.Equal(t, envMap["HOME"], "/tmp/home")
+	assert.Equal(t, envMap["LC_MESSAGES"], "en_US.UTF-8")
+	assert.Equal(t, envMap["CUSTOM_EXTRA"], "enabled")
+	_, hasSecret := envMap["AWS_SECRET_ACCESS_KEY"]
+	assert.Assert(t, !hasSecret)
+	_, hasMissing := envMap["MISSING_EXTRA"]
+	assert.Assert(t, !hasMissing)
+}
+
 func TestRunExecCommand(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 
@@ -1421,6 +1446,23 @@ func TestRunExecCommand(t *testing.T) {
 		assert.Assert(t, strings.Contains(envOutput, "GOSMEE_TIMESTAMP=2023-10-27T10.00.01.000"))
 		assert.Assert(t, strings.Contains(envOutput, "GOSMEE_PAYLOAD_FILE="))
 		assert.Assert(t, strings.Contains(envOutput, "GOSMEE_HEADERS_FILE="))
+	})
+
+	t.Run("parent secret env vars are not leaked and PATH is present", func(t *testing.T) {
+		t.Setenv("PATH", "/usr/bin:/bin")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "top-secret-value")
+		tmpFile := filepath.Join(t.TempDir(), "env-all.txt")
+		opts := &replayDataOpts{
+			execCommand: fmt.Sprintf("env > %s", tmpFile),
+			decorate:    false,
+		}
+		err := runExecCommand(context.Background(), opts, logger, basePM)
+		assert.NilError(t, err)
+		data, err := os.ReadFile(tmpFile)
+		assert.NilError(t, err)
+		envOutput := string(data)
+		assert.Assert(t, strings.Contains(envOutput, "PATH=/usr/bin:/bin"))
+		assert.Assert(t, !strings.Contains(envOutput, "AWS_SECRET_ACCESS_KEY=top-secret-value"))
 	})
 
 	t.Run("payload file contains body", func(t *testing.T) {

--- a/gosmee/flags.go
+++ b/gosmee/flags.go
@@ -187,6 +187,11 @@ var serverFlags = []cli.Flag{
 		Usage:   "Secret tokens to validate webhook signatures (GitHub, GitLab and many others). Can be specified multiple times",
 		EnvVars: []string{"GOSMEE_WEBHOOK_SIGNATURE"},
 	},
+	&cli.StringFlag{
+		Name:    "replay-token",
+		Usage:   "Bearer token required to authenticate replay requests to POST /replay/{channel}. When not set, the replay endpoint remains open for backward compatibility",
+		EnvVars: []string{"GOSMEE_REPLAY_TOKEN"},
+	},
 	&cli.IntFlag{
 		Name:    "max-body-size",
 		Usage:   "Maximum body size in bytes for incoming webhooks",

--- a/gosmee/flags.go
+++ b/gosmee/flags.go
@@ -203,4 +203,10 @@ var serverFlags = []cli.Flag{
 		Usage:   "Optional JSON file describing protected channel IDs and allowed client public keys",
 		EnvVars: []string{"GOSMEE_ENCRYPTED_CHANNELS_FILE"},
 	},
+	&cli.StringFlag{
+		Name:    "cors-origin",
+		Usage:   "CORS origin for SSE endpoint. Set a specific origin (e.g. https://example.com) to restrict which websites can connect to the SSE stream; set empty string to omit Access-Control-Allow-Origin entirely (same-origin only)",
+		Value:   "*",
+		EnvVars: []string{"GOSMEE_CORS_ORIGIN"},
+	},
 }

--- a/gosmee/flags.go
+++ b/gosmee/flags.go
@@ -54,6 +54,11 @@ var commonFlags = []cli.Flag{
 		Aliases: []string{"E"},
 		Usage:   "Only run --exec on these event types (e.g., push, pull_request). If not set, --exec runs on all events",
 	},
+	&cli.StringSliceFlag{
+		Name:    "exec-env-vars",
+		Usage:   "Additional environment variable names to pass through to --exec commands. Can be specified multiple times",
+		EnvVars: []string{"GOSMEE_EXEC_ENV_VARS"},
+	},
 }
 
 var replayFlags = []cli.Flag{

--- a/gosmee/replay.go
+++ b/gosmee/replay.go
@@ -235,6 +235,7 @@ func replay(c *cli.Context) error {
 		insecureTLSVerify: c.Bool("insecure-skip-tls-verify"),
 		execCommand:       c.String("exec"),
 		execOnEvents:      c.StringSlice("exec-on-events"),
+		execEnvVars:       c.StringSlice("exec-env-vars"),
 	}
 	return ropt.replayHooks(ctx, hookID)
 }

--- a/gosmee/server.go
+++ b/gosmee/server.go
@@ -173,7 +173,7 @@ func showNewURL(publicURL string, protectedChannels *ProtectedChannels) http.Han
 	}
 }
 
-func serveIndex(publicURL, footer, replayToken string, protectedChannels *ProtectedChannels) http.HandlerFunc {
+func serveIndex(publicURL, footer string, protectedChannels *ProtectedChannels) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		channel := chi.URLParam(r, "channel")
 		if channel == "" {
@@ -197,12 +197,11 @@ func serveIndex(publicURL, footer, replayToken string, protectedChannels *Protec
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
 		varmap := map[string]any{
-			"URL":         url,
-			"EventsURL":   eventsURL,
-			"Channel":     channel,
-			"Version":     string(Version),
-			"ReplayToken": replayToken,
-			"Footer":      template.HTML(footer), //nolint:gosec // operator-trusted input; intentionally rendered as raw HTML
+			"URL":       url,
+			"EventsURL": eventsURL,
+			"Channel":   channel,
+			"Version":   string(Version),
+			"Footer":    template.HTML(footer), //nolint:gosec // operator-trusted input; intentionally rendered as raw HTML
 		}
 		if err := t.ExecuteTemplate(w, "index", varmap); err != nil {
 			errorIt(w, r, http.StatusInternalServerError, err)
@@ -381,6 +380,10 @@ func handleWebhookPost(c *cli.Context, events *sse.Server, eventBroker *EventBro
 // handleReplayPost handles POST requests to the replay endpoint.
 func handleReplayPost(c *cli.Context, events *sse.Server, eventBroker *EventBroker) http.HandlerFunc {
 	replayToken := c.String("replay-token")
+	// Hash the expected token once so the comparison operates on fixed-length
+	// digests, avoiding leaking the token length via ConstantTimeCompare's
+	// early return on length mismatch.
+	expectedTokenHash := sha256.Sum256([]byte(replayToken))
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if replayToken != "" {
@@ -391,7 +394,8 @@ func handleReplayPost(c *cli.Context, events *sse.Server, eventBroker *EventBrok
 			}
 
 			providedToken := strings.TrimPrefix(authorizationHeader, "Bearer ")
-			if subtle.ConstantTimeCompare([]byte(providedToken), []byte(replayToken)) != 1 {
+			providedTokenHash := sha256.Sum256([]byte(providedToken))
+			if subtle.ConstantTimeCompare(providedTokenHash[:], expectedTokenHash[:]) != 1 {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
@@ -733,9 +737,9 @@ func serve(c *cli.Context) error {
 		w.Header().Set("Content-Type", "image/svg+xml")
 		_, _ = w.Write(faviconSVG)
 	})
-	mainRouter.Get("/", serveIndex(publicURL, footer, c.String("replay-token"), protectedChannels))
+	mainRouter.Get("/", serveIndex(publicURL, footer, protectedChannels))
 	mainRouter.Get("/new", showNewURL(publicURL, protectedChannels))
-	mainRouter.Get(channelPath, serveIndex(publicURL, footer, c.String("replay-token"), protectedChannels))
+	mainRouter.Get(channelPath, serveIndex(publicURL, footer, protectedChannels))
 	mainRouter.Get("/version", retVersion)
 	mainRouter.Get("/health", retVersion)
 	mainRouter.Get("/livez", retVersion)

--- a/gosmee/server.go
+++ b/gosmee/server.go
@@ -17,7 +17,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"text/template"
+	"html/template"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -196,12 +196,12 @@ func serveIndex(publicURL, footer string, protectedChannels *ProtectedChannels) 
 
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
-		varmap := map[string]string{
+		varmap := map[string]any{
 			"URL":       url,
 			"EventsURL": eventsURL,
 			"Channel":   channel,
 			"Version":   string(Version),
-			"Footer":    footer,
+			"Footer":    template.HTML(footer), //nolint:gosec // operator-trusted input; intentionally rendered as raw HTML
 		}
 		if err := t.ExecuteTemplate(w, "index", varmap); err != nil {
 			errorIt(w, r, http.StatusInternalServerError, err)

--- a/gosmee/server.go
+++ b/gosmee/server.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"io"
 	"net"
 	"net/http"
@@ -17,7 +18,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"html/template"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -582,7 +582,7 @@ func retVersion(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-func handleEventsGet(eventBroker *EventBroker, protectedChannels *ProtectedChannels) http.HandlerFunc {
+func handleEventsGet(eventBroker *EventBroker, protectedChannels *ProtectedChannels, corsOrigin string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		channel := chi.URLParam(r, "channel")
 		if channel == "" {
@@ -617,7 +617,9 @@ func handleEventsGet(eventBroker *EventBroker, protectedChannels *ProtectedChann
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("X-Accel-Buffering", "no")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		if corsOrigin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", corsOrigin)
+		}
 
 		// Get the flusher for immediate writes
 		flusher, ok := w.(http.Flusher)
@@ -668,6 +670,7 @@ func handleEventsGet(eventBroker *EventBroker, protectedChannels *ProtectedChann
 
 func serve(c *cli.Context) error {
 	publicURL := c.String("public-url")
+	corsOrigin := c.String("cors-origin")
 	footer := c.String("footer")
 	footerFile := c.String("footer-file")
 	if footer != "" && footerFile != "" {
@@ -738,7 +741,7 @@ func serve(c *cli.Context) error {
 	mainRouter.Get("/livez", retVersion)
 
 	// SSE endpoint for event streaming
-	mainRouter.Get(eventsPath, handleEventsGet(eventBroker, protectedChannels))
+	mainRouter.Get(eventsPath, handleEventsGet(eventBroker, protectedChannels, corsOrigin))
 
 	// Register POST routes on the restricted router
 	restrictedRouter.Post(channelPath, handleWebhookPost(c, events, eventBroker, c.StringSlice("webhook-signature")))

--- a/gosmee/server.go
+++ b/gosmee/server.go
@@ -173,7 +173,7 @@ func showNewURL(publicURL string, protectedChannels *ProtectedChannels) http.Han
 	}
 }
 
-func serveIndex(publicURL, footer string, protectedChannels *ProtectedChannels) http.HandlerFunc {
+func serveIndex(publicURL, footer, replayToken string, protectedChannels *ProtectedChannels) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		channel := chi.URLParam(r, "channel")
 		if channel == "" {
@@ -197,11 +197,12 @@ func serveIndex(publicURL, footer string, protectedChannels *ProtectedChannels) 
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)
 		varmap := map[string]any{
-			"URL":       url,
-			"EventsURL": eventsURL,
-			"Channel":   channel,
-			"Version":   string(Version),
-			"Footer":    template.HTML(footer), //nolint:gosec // operator-trusted input; intentionally rendered as raw HTML
+			"URL":         url,
+			"EventsURL":   eventsURL,
+			"Channel":     channel,
+			"Version":     string(Version),
+			"ReplayToken": replayToken,
+			"Footer":      template.HTML(footer), //nolint:gosec // operator-trusted input; intentionally rendered as raw HTML
 		}
 		if err := t.ExecuteTemplate(w, "index", varmap); err != nil {
 			errorIt(w, r, http.StatusInternalServerError, err)
@@ -379,7 +380,23 @@ func handleWebhookPost(c *cli.Context, events *sse.Server, eventBroker *EventBro
 
 // handleReplayPost handles POST requests to the replay endpoint.
 func handleReplayPost(c *cli.Context, events *sse.Server, eventBroker *EventBroker) http.HandlerFunc {
+	replayToken := c.String("replay-token")
+
 	return func(w http.ResponseWriter, r *http.Request) {
+		if replayToken != "" {
+			authorizationHeader := r.Header.Get("Authorization")
+			if !strings.HasPrefix(authorizationHeader, "Bearer ") {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			providedToken := strings.TrimPrefix(authorizationHeader, "Bearer ")
+			if subtle.ConstantTimeCompare([]byte(providedToken), []byte(replayToken)) != 1 {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+
 		channel := chi.URLParam(r, "channel")
 		if channel == "" {
 			http.Error(w, "Channel name missing in URL", http.StatusBadRequest)
@@ -409,6 +426,9 @@ func handleReplayPost(c *cli.Context, events *sse.Server, eventBroker *EventBrok
 		payload := make(map[string]any)
 		// Add basic headers from the replay request
 		for k, v := range r.Header {
+			if strings.EqualFold(k, "Authorization") {
+				continue
+			}
 			payload[strings.ToLower(k)] = v[0]
 		}
 		// Add timestamp and encode the body
@@ -710,9 +730,9 @@ func serve(c *cli.Context) error {
 		w.Header().Set("Content-Type", "image/svg+xml")
 		_, _ = w.Write(faviconSVG)
 	})
-	mainRouter.Get("/", serveIndex(publicURL, footer, protectedChannels))
+	mainRouter.Get("/", serveIndex(publicURL, footer, c.String("replay-token"), protectedChannels))
 	mainRouter.Get("/new", showNewURL(publicURL, protectedChannels))
-	mainRouter.Get(channelPath, serveIndex(publicURL, footer, protectedChannels))
+	mainRouter.Get(channelPath, serveIndex(publicURL, footer, c.String("replay-token"), protectedChannels))
 	mainRouter.Get("/version", retVersion)
 	mainRouter.Get("/health", retVersion)
 	mainRouter.Get("/livez", retVersion)

--- a/gosmee/server_test.go
+++ b/gosmee/server_test.go
@@ -458,7 +458,7 @@ func TestHandleEventsGet(t *testing.T) {
 		"test-channel": {allowedKey},
 	})
 	router := chi.NewRouter()
-	router.Get("/events/{channel:[a-zA-Z0-9_-]{12,64}}", handleEventsGet(eventBroker, protectedChannels))
+	router.Get("/events/{channel:[a-zA-Z0-9_-]{12,64}}", handleEventsGet(eventBroker, protectedChannels, "*"))
 
 	t.Run("Rejects Invalid Public Key", func(t *testing.T) {
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/events/test-channel?pubkey=!!!", nil)
@@ -551,7 +551,7 @@ func TestHandleEventsGet(t *testing.T) {
 			"test-channel": {allowed},
 		})
 		router = chi.NewRouter()
-		router.Get("/events/{channel:[a-zA-Z0-9_-]{12,64}}", handleEventsGet(eventBroker, protectedChannels))
+		router.Get("/events/{channel:[a-zA-Z0-9_-]{12,64}}", handleEventsGet(eventBroker, protectedChannels, "*"))
 
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/events/test-channel?pubkey="+url.QueryEscape(allowed), nil)
 		reqCtx, cancel := context.WithCancel(req.Context())
@@ -590,6 +590,69 @@ func TestHandleEventsGet(t *testing.T) {
 		cancel()
 		<-done
 	})
+}
+
+func TestHandleEventsGetCORSOrigin(t *testing.T) {
+	testCases := []struct {
+		name           string
+		corsOrigin     string
+		expectedHeader string
+		expectPresent  bool
+	}{
+		{
+			name:           "Wildcard Origin",
+			corsOrigin:     "*",
+			expectedHeader: "*",
+			expectPresent:  true,
+		},
+		{
+			name:           "Specific Origin",
+			corsOrigin:     "https://example.com",
+			expectedHeader: "https://example.com",
+			expectPresent:  true,
+		},
+		{
+			name:          "Empty Origin Omits Header",
+			corsOrigin:    "",
+			expectPresent: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eventBroker := NewEventBroker()
+			protectedChannels, err := LoadProtectedChannels("")
+			assert.NilError(t, err)
+			router := chi.NewRouter()
+			router.Get("/events/{channel:[a-zA-Z0-9_-]{12,64}}", handleEventsGet(eventBroker, protectedChannels, tc.corsOrigin))
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/events/plainchannel1", nil)
+			reqCtx, cancel := context.WithCancel(req.Context())
+			req = req.WithContext(reqCtx)
+			defer cancel()
+
+			response := httptest.NewRecorder()
+			done := make(chan struct{})
+			go func() {
+				router.ServeHTTP(response, req)
+				close(done)
+			}()
+
+			assert.Assert(t, eventually(t, func() bool {
+				return strings.Contains(response.Body.String(), `{"message":"connected"}`)
+			}))
+
+			headerValue := response.Header().Get("Access-Control-Allow-Origin")
+			if tc.expectPresent {
+				assert.Equal(t, headerValue, tc.expectedHeader)
+			} else {
+				assert.Equal(t, headerValue, "")
+			}
+
+			cancel()
+			<-done
+		})
+	}
 }
 
 func TestServeIndexAndNewURL(t *testing.T) {

--- a/gosmee/server_test.go
+++ b/gosmee/server_test.go
@@ -558,8 +558,10 @@ func TestServeIndexAndNewURL(t *testing.T) {
 		assert.Equal(t, resp.StatusCode, http.StatusOK)
 		body, err := io.ReadAll(resp.Body)
 		assert.NilError(t, err)
-		assert.Assert(t, strings.Contains(string(body), "plainchannel1"))
-		assert.Assert(t, strings.Contains(string(body), "/events/plainchannel1"))
+		bodyStr := string(body)
+		assert.Assert(t, strings.Contains(bodyStr, "plainchannel1"))
+		// html/template contextually escapes JS strings, so "/" is rendered as `\/` in script blocks.
+		assert.Assert(t, strings.Contains(bodyStr, "/events/plainchannel1") || strings.Contains(bodyStr, "\\/events\\/plainchannel1"))
 	})
 
 	t.Run("protected channel page is hidden", func(t *testing.T) {

--- a/gosmee/server_test.go
+++ b/gosmee/server_test.go
@@ -219,6 +219,7 @@ func newTestContext() *cli.Context {
 	app := cli.NewApp()
 	flagSet := flag.NewFlagSet("test", 0)
 	flagSet.Int("max-body-size", 26214400, "doc")
+	flagSet.String("replay-token", "", "doc")
 	return cli.NewContext(app, flagSet, nil)
 }
 
@@ -383,6 +384,73 @@ func TestHandleWebhookPost(t *testing.T) {
 	})
 }
 
+func TestHandleReplayPost(t *testing.T) {
+	makeReplayRequest := func(t *testing.T, replayToken, authHeader string) *httptest.ResponseRecorder {
+		t.Helper()
+
+		events := sse.New()
+		eventBroker := NewEventBroker()
+		subscriber := eventBroker.Subscribe("test-channel", nil)
+		defer eventBroker.Unsubscribe("test-channel", subscriber)
+
+		ctx := newTestContext()
+		assert.NilError(t, ctx.Set("replay-token", replayToken))
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/replay/test-channel", strings.NewReader(`{"event":"replay"}`))
+		req.Header.Set("Content-Type", contentType)
+		if authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("channel", "test-channel")
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+		w := httptest.NewRecorder()
+		handler := handleReplayPost(ctx, events, eventBroker)
+		handler(w, req)
+
+		if w.Code == http.StatusAccepted {
+			select {
+			case event := <-subscriber.Events:
+				var eventData map[string]any
+				err := json.Unmarshal(event, &eventData)
+				assert.NilError(t, err)
+				assert.Assert(t, eventData["authorization"] == nil)
+			default:
+				t.Fatal("Expected event to be published but none was received")
+			}
+		}
+
+		return w
+	}
+
+	t.Run("No token configured and no auth header returns accepted", func(t *testing.T) {
+		resp := makeReplayRequest(t, "", "")
+		assert.Equal(t, resp.Code, http.StatusAccepted)
+	})
+
+	t.Run("Token configured and correct bearer auth returns accepted", func(t *testing.T) {
+		resp := makeReplayRequest(t, "test-replay-token", "Bearer test-replay-token")
+		assert.Equal(t, resp.Code, http.StatusAccepted)
+	})
+
+	t.Run("Token configured and wrong bearer auth returns unauthorized", func(t *testing.T) {
+		resp := makeReplayRequest(t, "test-replay-token", "Bearer wrong-token")
+		assert.Equal(t, resp.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Token configured and missing auth header returns unauthorized", func(t *testing.T) {
+		resp := makeReplayRequest(t, "test-replay-token", "")
+		assert.Equal(t, resp.Code, http.StatusUnauthorized)
+	})
+
+	t.Run("Token configured and malformed auth header returns unauthorized", func(t *testing.T) {
+		resp := makeReplayRequest(t, "test-replay-token", "Basic xxx")
+		assert.Equal(t, resp.Code, http.StatusUnauthorized)
+	})
+}
+
 func TestHandleEventsGet(t *testing.T) {
 	eventBroker := NewEventBroker()
 	allowedKey := mustGeneratePublicKey(t)
@@ -533,7 +601,7 @@ func TestServeIndexAndNewURL(t *testing.T) {
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 
-		handler := serveIndex("https://example.com", "", protectedChannels)
+		handler := serveIndex("https://example.com", "", "", protectedChannels)
 		handler(w, req)
 
 		resp := w.Result()
@@ -551,7 +619,7 @@ func TestServeIndexAndNewURL(t *testing.T) {
 		rctx.URLParams.Add("channel", "plainchannel1")
 		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-		handler := serveIndex("https://example.com", "footer text", protectedChannels)
+		handler := serveIndex("https://example.com", "footer text", "", protectedChannels)
 		handler(w, req)
 
 		resp := w.Result()
@@ -572,7 +640,7 @@ func TestServeIndexAndNewURL(t *testing.T) {
 		rctx.URLParams.Add("channel", "protectedchan")
 		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-		handler := serveIndex("https://example.com", "", protectedChannels)
+		handler := serveIndex("https://example.com", "", "", protectedChannels)
 		handler(w, req)
 
 		assert.Equal(t, w.Result().StatusCode, http.StatusNotFound)

--- a/gosmee/server_test.go
+++ b/gosmee/server_test.go
@@ -664,7 +664,7 @@ func TestServeIndexAndNewURL(t *testing.T) {
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 
-		handler := serveIndex("https://example.com", "", "", protectedChannels)
+		handler := serveIndex("https://example.com", "", protectedChannels)
 		handler(w, req)
 
 		resp := w.Result()
@@ -682,7 +682,7 @@ func TestServeIndexAndNewURL(t *testing.T) {
 		rctx.URLParams.Add("channel", "plainchannel1")
 		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-		handler := serveIndex("https://example.com", "footer text", "", protectedChannels)
+		handler := serveIndex("https://example.com", "footer text", protectedChannels)
 		handler(w, req)
 
 		resp := w.Result()
@@ -703,7 +703,7 @@ func TestServeIndexAndNewURL(t *testing.T) {
 		rctx.URLParams.Add("channel", "protectedchan")
 		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-		handler := serveIndex("https://example.com", "", "", protectedChannels)
+		handler := serveIndex("https://example.com", "", protectedChannels)
 		handler(w, req)
 
 		assert.Equal(t, w.Result().StatusCode, http.StatusNotFound)

--- a/gosmee/templates/index.tmpl
+++ b/gosmee/templates/index.tmpl
@@ -718,6 +718,7 @@
         const instructionsContainer = document.getElementById('instructions-container');
         const mainContent = document.getElementById('main-content');
         const eventsUrl = '{{ .EventsURL }}';
+        const replayToken = '{{ .ReplayToken }}';
         let eventCount = 0;
         let eventSource;
         // Store JSON editors for each event
@@ -1112,6 +1113,9 @@
             // Get channel from URL
             const channel = window.location.pathname.split('/').pop();
             const payload = JSON.parse(rawContent.textContent);
+            if (replayToken) {
+                headers['Authorization'] = `Bearer ${replayToken}`;
+            }
 
             // Send replay request
             fetch(`/replay/${channel}`, {

--- a/gosmee/templates/index.tmpl
+++ b/gosmee/templates/index.tmpl
@@ -870,9 +870,9 @@
                             <i class="fas fa-redo-alt"></i> 
                             Replay
                         </button>
-                        <span class="event-id">Event ID: ${eventId}</span>
+                        <span class="event-id">Event ID: ${escapeHtml(String(eventId))}</span>
                     </div>
-                    <span class="event-time">${timestamp}</span>
+                    <span class="event-time">${escapeHtml(String(timestamp))}</span>
                 </div>
                 <div class="event-payload">
                     <!-- Headers section -->

--- a/gosmee/templates/index.tmpl
+++ b/gosmee/templates/index.tmpl
@@ -718,7 +718,6 @@
         const instructionsContainer = document.getElementById('instructions-container');
         const mainContent = document.getElementById('main-content');
         const eventsUrl = '{{ .EventsURL }}';
-        const replayToken = '{{ .ReplayToken }}';
         let eventCount = 0;
         let eventSource;
         // Store JSON editors for each event
@@ -1076,6 +1075,18 @@
             }
         }
 
+        // Function to get replay token (from sessionStorage or prompt)
+        function getReplayToken() {
+            let token = sessionStorage.getItem('gosmee-replay-token');
+            if (!token) {
+                token = prompt('Enter replay token (leave empty if server does not require authentication):');
+                if (token) {
+                    sessionStorage.setItem('gosmee-replay-token', token);
+                }
+            }
+            return token;
+        }
+
         // Function to replay an event
         window.replayEvent = function (id, event) {
             event.preventDefault();
@@ -1113,19 +1124,43 @@
             // Get channel from URL
             const channel = window.location.pathname.split('/').pop();
             const payload = JSON.parse(rawContent.textContent);
-            if (replayToken) {
-                headers['Authorization'] = `Bearer ${replayToken}`;
-            }
 
-            // Send replay request
-            fetch(`/replay/${channel}`, {
-                method: 'POST',
-                headers: headers,
-                credentials: 'omit',
-                body: JSON.stringify(payload)
-            })
+            // Helper function to attempt replay
+            const attemptReplay = (authToken) => {
+                const requestHeaders = { ...headers };
+                if (authToken) {
+                    requestHeaders['Authorization'] = `Bearer ${authToken}`;
+                }
+
+                return fetch(`/replay/${channel}`, {
+                    method: 'POST',
+                    headers: requestHeaders,
+                    credentials: 'omit',
+                    body: JSON.stringify(payload)
+                });
+            };
+
+            // Try replay without token first
+            attemptReplay(null)
+                .then(response => {
+                    if (response.status === 401) {
+                        // Server requires authentication, prompt for token
+                        const token = getReplayToken();
+                        if (!token) {
+                            throw new Error('Replay requires authentication');
+                        }
+                        // Retry with token
+                        return attemptReplay(token);
+                    }
+                    return response;
+                })
                 .then(response => {
                     if (!response.ok) {
+                        if (response.status === 401) {
+                            // Token was invalid, clear it and prompt again
+                            sessionStorage.removeItem('gosmee-replay-token');
+                            throw new Error('Invalid replay token. Please try again.');
+                        }
                         throw new Error(`Replay failed: ${response.status} ${response.statusText}`);
                     }
                     return response.text();


### PR DESCRIPTION
- **security: fix TLS certificate check being silently disabled by default**
- **security: prevent malicious webhook headers from injecting code into the browser UI**
- **security: switch HTML page rendering to use Go's safer template engine**
- **security: stop leaking secrets to shell commands run by --exec**
- **security: protect the replay endpoint with an optional bearer token**
- **security: allow restricting which websites can connect to the event stream**
- **docs: document new security flags added by recent fixes**

### Kubernetes TLS behavior note

The TLS verification fix changes the default for forwarding to `https://` targets: gosmee now verifies the target certificate by default instead of silently skipping verification.

This is a security fix, but it may affect Kubernetes deployments that forward to internal HTTPS services using self-signed certificates, private/internal CAs, mismatched service DNS names, or images without the required CA roots installed.

Affected users can temporarily keep the old behavior with `--insecure-skip-tls-verify`. A better long-term setup is to use a certificate trusted by the gosmee container, or add future support for a mounted CA bundle via a dedicated option such as `--tls-ca-file`.
